### PR TITLE
API GW deployments should not be deleted when API changes are triggered.

### DIFF
--- a/aws/resource_aws_api_gateway_deployment.go
+++ b/aws/resource_aws_api_gateway_deployment.go
@@ -45,7 +45,6 @@ func resourceAwsApiGatewayDeployment() *schema.Resource {
 			"triggers": {
 				Type:     schema.TypeMap,
 				Optional: true,
-				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
@@ -158,6 +157,12 @@ func resourceAwsApiGatewayDeploymentUpdateOperations(d *schema.ResourceData) []*
 
 func resourceAwsApiGatewayDeploymentUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).apigatewayconn
+
+	if d.HasChange("triggers") {
+		log.Printf("[DEBUG] Update to triggers causes new deployment API Gateway API Key: %s", d.Id())
+
+		return resourceAwsApiGatewayDeploymentCreate(d, meta)
+	}
 
 	log.Printf("[DEBUG] Updating API Gateway API Key: %s", d.Id())
 


### PR DESCRIPTION
With hashicorp/aws, API gateway deployments are ALWAYS re-created and deleted when changes to the API configuration are detected using `triggers`. We prefer to keep previous deployments instead of replacing them.

To circumvent this issue, we have modified the aws terraform provider to create a __new deployment__ whenever it detects a change to the `triggers` attribute of an `aws_api_gateway_deployment` resource, without deleting the previous deployment. Terraform `plan` or `apply` diff output will indicate an **update** of the resource, instead of a replacement (as done by the hashicorp/aws provider), even though a new resource is being created.

As a consequence of this change, and since it doesn't fit the terraform way of doing things, the `id` attribute should NOT be used by stages to indicate the currently active deployment (the provider SDK won't allow for updating ids). Instead, a new `refreshed_id` attribute has been added, containing the same value as `id`, and should be used instead. It will allow for detecting and chaining the changes appropriately.